### PR TITLE
chore: フロントエンド側の画像インポート先の用意

### DIFF
--- a/backend/.env.dev-server-debug
+++ b/backend/.env.dev-server-debug
@@ -9,7 +9,7 @@ DB_PORT=5432
 DEBUG=True
 LOGGER_LEVEL=DEBUG
 ALLOWED_HOSTS=dev-portal.oku.cccties.org
-IMAGE_DIR=./images
+IMAGE_DIR=../frontend/public/images
 JUDGE_BADGE=alignments
 PER_PAGE=30
 # db

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ${APP_PORT}:8000
     volumes:
       - ./:/workspace
-      - ${IMAGE_DIR}:/workspace/output/images/
+      -  ${PWD}/${IMAGE_DIR}:/workspace/output/images/
     environment:
       - SECRET_KEY=$SECRET_KEY
       - DB_HOST=$DB_HOST


### PR DESCRIPTION
resolve #93

以下への対応です

> > webroot を環境変数、そこから先を固定にするとかで良いのではないでしょうか。
> 
> https://github.com/npocccties/chiloportal/tree/develop/backend#%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%AA%AC%E6%98%8E にあるとおりバックエンドとしては環境変数 `IMAGE_DIR` が存在しているので、
> 
> - [ ] フロントエンド側でインポート用のディレクトリを用意する
> - [ ] [env.dev-server-debug](https://github.com/npocccties/chiloportal/blob/develop/backend/.env.dev-server-debug)のIMAGE_DIRを用意したディレクトリへの相対パスに変更する
> 
> という作業が必要かなと思いました（ちがっていれば指摘いただければと）

_Originally posted by @knokmki612 in https://github.com/npocccties/chiloportal/issues/93#issuecomment-1259062146_
      