### PR TITLE
chore: エディタの保存時整形対象のファイルタイプの調整

### DIFF
--- a/frontend/.vim/coc-settings.json
+++ b/frontend/.vim/coc-settings.json
@@ -1,9 +1,9 @@
 {
   "coc.preferences.formatOnSaveFiletypes": [
     "javscript",
-    "javascript.react",
+    "javascriptreact",
     "typescript",
-    "typescript.react",
+    "typescriptreact",
     "json",
     "yaml"
   ]


### PR DESCRIPTION
意図しないファイルタイプを指定しており `.tsx` `.jsx` 編集時整形が効かない件への対応