### PR TITLE
feat: useConsumers / usePortalCategories フックの実装

### DIFF
--- a/frontend/lib/use-consumers.ts
+++ b/frontend/lib/use-consumers.ts
@@ -1,0 +1,14 @@
+import useSWRImmutable from "swr/immutable";
+import { client } from "lib/client";
+import { Consumer } from "api/@types";
+
+const key = "consumer/list" as const;
+
+async function fetcher(_: typeof key) {
+  const { body } = await client.consumer.list.get();
+  return body;
+}
+
+export default function useConsumers() {
+  return useSWRImmutable<Consumer[]>(key, fetcher);
+}

--- a/frontend/lib/use-portal-categories.ts
+++ b/frontend/lib/use-portal-categories.ts
@@ -1,0 +1,14 @@
+import useSWRImmutable from "swr/immutable";
+import { client } from "lib/client";
+import { PortalCategory } from "api/@types";
+
+const key = "portal_category/list" as const;
+
+async function fetcher(_: typeof key) {
+  const { body } = await client.portalCategory.list.get();
+  return body;
+}
+
+export default function useConsumers() {
+  return useSWRImmutable<PortalCategory[]>(key, fetcher);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "postcss": "^8.4.17",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
+    "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
     "typescript": "^4.8.4",
     "yn": "^5.0.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2067,6 +2067,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^3.0.2
+    swr: ^1.3.0
     tailwindcss: ^3.1.8
     typescript: ^4.8.4
     yn: ^5.0.0
@@ -4676,6 +4677,15 @@ __metadata:
     oas-validate: oas-validate.js
     swagger2openapi: swagger2openapi.js
   checksum: dd0ee3b9dc3517639215471ec5bb013fcf2aa65dbee9089ec2ec4d911981ae381c63261a0a2f4e90cda668da27db6d2f5fdb89b0775cd1463a3a7f98d319c7ac
+  languageName: node
+  linkType: hard
+
+"swr@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "swr@npm:1.3.0"
+  peerDependencies:
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0
+  checksum: e7a184f0d560e9c8be85c023cc8e65e56a88a6ed46f9394b301b07f838edca23d2e303685319a4fcd620b81d447a7bcb489c7fa0a752c259f91764903c690cdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
resolve #3

共通レイアウト（ヘッダー / フッター）で必要なデータを
クライアント側で取得する目的