### PR TITLE
fix: yarn dev 時開発サーバーが起動しない

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "build:app": "next build",
     "build:clean": "rimraf public/mockServiceWorker.js",
     "build:path": "pathpida --ignorePath .gitignore",
-    "dev": "run-s api dev:mock dev:path dev:app",
+    "dev": "npm-run-all -s api dev:mock -p dev:path dev:app",
     "dev:app": "next dev",
     "dev:mock": "msw init public --no-save",
     "dev:path": "pathpida --ignorePath .gitignore --watch",


### PR DESCRIPTION
yarn dev:path のプロセスが終了せず
開発サーバー起動のコマンドが実行されないため
並列にコマンドを実行することで対処