### PR TITLE
fix: Error serializing `.keyword`

### DIFF
--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -12,7 +12,7 @@ export type Props = {
 };
 
 export async function getServerSideProps({
-  query: { q, p },
+  query: { q = "", p },
 }: Context): Promise<{ props: Props }> {
   const { body: wisdomBadgesList } = await client.wisdomBadges.list.keyword.get(
     {


### PR DESCRIPTION
下記のフロントエンドサーバーエラーへの対応
undefined のシリアライズに失敗していることが原因
文字列を想定するクエリパラメータなので常に文字列が渡されるように対処

```
Error: Error serializing `.keyword` returned from `getServerSideProps` in "/search".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```