### PR TITLE
fix: templates 配下のコンポーネントで tailwindcss が使用できない

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["pages/**/*.{js,ts,jsx,tsx}", "components/**/*.{js,ts,jsx,tsx}"],
+  content: ["{pages,templates,components}/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
contents として指定する glob で考慮できていないことが原因
https://tailwindcss.com/docs/content-configuration