### PR TITLE
refactor: 冗長なレスポンスの抽出

### DIFF
--- a/frontend/lib/use-consumers.ts
+++ b/frontend/lib/use-consumers.ts
@@ -5,8 +5,7 @@ import { Consumer } from "api/@types";
 const key = "consumer/list" as const;
 
 async function fetcher(_: typeof key) {
-  const { body } = await client.consumer.list.get();
-  return body;
+  return client.consumer.list.$get();
 }
 
 export default function useConsumers() {

--- a/frontend/lib/use-portal-categories.ts
+++ b/frontend/lib/use-portal-categories.ts
@@ -5,8 +5,7 @@ import { PortalCategory } from "api/@types";
 const key = "portal_category/list" as const;
 
 async function fetcher(_: typeof key) {
-  const { body } = await client.portalCategory.list.get();
-  return body;
+  return client.portalCategory.list.$get();
 }
 
 export default function useConsumers() {

--- a/frontend/pages/consumers/[consumerId]/frameworks/[frameworkId]/stages/[stageId].tsx
+++ b/frontend/pages/consumers/[consumerId]/frameworks/[frameworkId]/stages/[stageId].tsx
@@ -24,18 +24,18 @@ export type Props = {
 export async function getServerSideProps({
   params: { consumerId, frameworkId, stageId },
 }: Context): Promise<{ props: ErrorProps | Props }> {
-  const { body: consumer } = await client.consumer.get({
+  const consumer = await client.consumer.$get({
     query: { consumer_id: Number(consumerId) },
   });
-  const { body: framework } = await client.framework.get({
+  const framework = await client.framework.$get({
     query: { framework_id: Number(frameworkId) },
   });
-  const { body: stages } = await client.framework.stage.list.get({
+  const stages = await client.framework.stage.list.$get({
     query: { framework_id: Number(frameworkId) },
   });
   const stage = stages.find((stage) => stage.stage_id === Number(stageId));
   if (!stage) return { props: { title: "Stage Not Found", statusCode: 404 } };
-  const { body: fields } = await client.stage.field.list.get({
+  const fields = await client.stage.field.list.$get({
     query: { stage_id: Number(stageId) },
   });
   const wisdomBadgesMap = new Map<number, BadgeDetail2[]>();
@@ -45,7 +45,7 @@ export async function getServerSideProps({
     )
   );
   for (const fieldId of fieldIds) {
-    const { body: wisdomBadges } = await client.wisdomBadges.list.get({
+    const wisdomBadges = await client.wisdomBadges.list.$get({
       query: { field_id: fieldId, stage_id: Number(stageId) },
     });
     wisdomBadgesMap.set(fieldId, wisdomBadges.badges);

--- a/frontend/pages/consumers/[consumerId]/index.tsx
+++ b/frontend/pages/consumers/[consumerId]/index.tsx
@@ -17,17 +17,17 @@ export async function getServerSideProps({
 }: Context): Promise<{
   props: Props;
 }> {
-  const { body: consumer } = await client.consumer.get({
+  const consumer = await client.consumer.$get({
     query: { consumer_id: Number(consumerId) },
   });
-  const { body: frameworks } = await client.consumer.framework.list.get({
+  const frameworks = await client.consumer.framework.list.$get({
     query: { consumer_id: Number(consumerId) },
   });
   const stagesPerFrameworks = await Promise.all(
     frameworks.map(({ framework_id }) =>
-      client.framework.stage.list.get({ query: { framework_id } })
+      client.framework.stage.list.$get({ query: { framework_id } })
     )
-  ).then((value) => value.map((res) => res.body));
+  );
   return {
     props: { consumer, frameworks, stagesPerFrameworks },
   };

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -13,8 +13,8 @@ export type Props = {
 export async function getServerSideProps(): Promise<{
   props: Props;
 }> {
-  const { body: consumers } = await client.consumer.list.get();
-  const { body: portalCategories } = await client.portalCategory.list.get();
+  const consumers = await client.consumer.list.$get();
+  const portalCategories = await client.portalCategory.list.$get();
   return {
     props: {
       articles: [],

--- a/frontend/pages/portal_categories/[portalCategoryId].tsx
+++ b/frontend/pages/portal_categories/[portalCategoryId].tsx
@@ -26,7 +26,7 @@ export async function getServerSideProps({
   params: { portalCategoryId },
   query: { p },
 }: Context): Promise<{ props: ErrorProps | Props }> {
-  const { body: portalCategories } = await client.portalCategory.list.get();
+  const portalCategories = await client.portalCategory.list.$get();
   const portalCategory = NEXT_PUBLIC_API_MOCKING
     ? fakePortalCategory()
     : portalCategories.find(
@@ -35,13 +35,12 @@ export async function getServerSideProps({
       );
   if (!portalCategory)
     return { props: { title: "PortalCategory Not Found", statusCode: 404 } };
-  const { body: wisdomBadgesList } =
-    await client.portalCategory.badges.list.get({
-      query: {
-        portal_category_id: portalCategory.portal_category_id,
-        page_number: Number(p),
-      },
-    });
+  const wisdomBadgesList = await client.portalCategory.badges.list.$get({
+    query: {
+      portal_category_id: portalCategory.portal_category_id,
+      page_number: Number(p),
+    },
+  });
   return {
     props: { portalCategory, wisdomBadgesList },
   };

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -16,11 +16,9 @@ export type Props = {
 export async function getServerSideProps({
   query: { q = "", p },
 }: Context): Promise<{ props: Props }> {
-  const { body: wisdomBadgesList } = await client.wisdomBadges.list.keyword.get(
-    {
-      query: { keyword: q, page_number: Number(p) },
-    }
-  );
+  const wisdomBadgesList = await client.wisdomBadges.list.keyword.$get({
+    query: { keyword: q, page_number: Number(p) },
+  });
   return {
     props: { keyword: q, wisdomBadgesList },
   };

--- a/frontend/pages/wisdom_badges/[wisdomBadgesId].tsx
+++ b/frontend/pages/wisdom_badges/[wisdomBadgesId].tsx
@@ -21,9 +21,7 @@ export type Props = {
 export async function getServerSideProps({
   params: { wisdomBadgesId },
 }: Context): Promise<{ props: ErrorProps | Props }> {
-  const {
-    body: [wisdomBadges],
-  } = await client.badges.get({
+  const [wisdomBadges] = await client.badges.$get({
     query: {
       badges_ids: wisdomBadgesId,
       badges_type: "wisdom" as const,
@@ -35,7 +33,7 @@ export async function getServerSideProps({
     };
   if (!("knowledge_badges_list" in wisdomBadges.detail))
     return { props: { title: "KnowledgeBadges Not Found", statusCode: 404 } };
-  const { body: knowledgeBadgesList } = await client.badges.get({
+  const knowledgeBadgesList = await client.badges.$get({
     query: {
       badges_ids: wisdomBadges.detail.knowledge_badges_list.join(","),
       badges_type: "knowledge",


### PR DESCRIPTION
`$get()` を使用すればパースされたレスポンスボディが得られるので
それを利用することで抽出のためのコードを削減する目的