### PR TITLE
feat: 色の設定

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,26 @@
+const { stone } = require("tailwindcss/colors");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["{pages,templates,components}/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          50: "#fcf9f9",
+          100: "#fbf3f2",
+          200: "#f7eaea",
+          300: "#edd5d4",
+          400: "#dcaba9",
+          500: "#ca807f",
+          600: "b95654",
+          700: "#a72c29",
+          800: "#7d211f",
+          900: "#541615",
+        },
+        gray: stone,
+      },
+    },
   },
   plugins: [
     ...require("@jumpu-ui/tailwindcss"),


### PR DESCRIPTION
以下への対応

> @knokmki612 デザインシステムのカラー定義について共有
> 
> https://www.figma.com/file/dCE06JShf29eqnvZ4vcE8U/OKUTEP?node-id=731%3A6445
> 
> グレースケールについて、今回は少し赤みをもたせた tailwind css の colors.stone を使うつもりです。
> 

_Originally posted by @Hidetaro7 in https://github.com/npocccties/chiloportal/issues/194#issuecomment-1280421670_
      