### PR TITLE
fix: django-cors-headersのインストールとgunicornの実行はスクリプトから行うようにした（コンテナ作成時にdj…

### DIFF
--- a/backend/dev-server_start.sh
+++ b/backend/dev-server_start.sh
@@ -2,6 +2,10 @@
 sudo cp .env.dev-server .env
 sudo cp docker-compose.dev-server.yml docker-compose.yml
 docker-compose up -d
+# コンテナ作成時に requirements.txt から django-cors-headers をインストールしても /usr/local/lib/python3.9/site-packages にインストールされていないので、
+# デプロイのタイミングで django-cors-headers をインストールする
+docker-compose exec app pip install django-cors-headers
 docker-compose exec app python /workspace/manage.py makemigrations
 docker-compose exec app python /workspace/manage.py migrate
 docker-compose exec -d app python /workspace/manage.py collectstatic --no-input --clear
+docker-compose exec -d app gunicorn project.wsgi:application --bind 0.0.0.0:8000

--- a/backend/docker-compose.dev-server.yml
+++ b/backend/docker-compose.dev-server.yml
@@ -32,7 +32,7 @@ services:
 
   app:
     build: .
-    command: gunicorn project.wsgi:application --bind 0.0.0.0:8000
+    tty: true
     expose:
       - 8000
     networks:

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
     "chiloportal.apps.ChiloportalConfig",
     "rest_framework",
     "rest_framework_api_key",
-    # "corsheaders",
+    "corsheaders",
     "drf_yasg",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -53,7 +53,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    # "corsheaders.middleware.CorsMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
…ango-cors-headersがインストールできないため）