### PR TITLE
fix: バッジと関連性のないコンシューマーが含まれうる

### DIFF
--- a/frontend/lib/use-badges-frameworks.ts
+++ b/frontend/lib/use-badges-frameworks.ts
@@ -5,9 +5,12 @@ import { Consumer, Framework } from "api/@types";
 const key = "badges/consumer/list/consumer/framework/list" as const;
 
 async function fetcher(
-  _: typeof key
+  _: typeof key,
+  badgesId: number
 ): Promise<{ consumers: Consumer[]; frameworksPerConsumers: Framework[][] }> {
-  const consumers = await client.consumer.list.$get();
+  const consumers = await client.wisdomBadges.consumer.list.$get({
+    query: { badges_id: badgesId },
+  });
   const frameworksPerConsumers = await Promise.all(
     consumers.map((consumer) =>
       client.consumer.framework.list.$get({


### PR DESCRIPTION
あやまった API を使用していることが原因