### PR TITLE
chore: filename-match-exported の調整

### DIFF
--- a/frontend/.eslintrc.yaml
+++ b/frontend/.eslintrc.yaml
@@ -6,7 +6,7 @@ plugins:
 rules:
   canonical/filename-match-exported: [error, kebab]
 overrides:
-  - files: "**/*.tsx"
+  - files: "{components,templates}/**/*.tsx"
     rules:
       canonical/filename-match-exported: [error, pascal]
   - files: "pages/**/*.tsx"


### PR DESCRIPTION
期待するディレクトリに対して期待する命名規則が適用されないケースがあるため