### PR TITLE
fix: 育成指標あるいはカテゴリの件数が多いと Popover が画面からはみ出る

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -53,7 +53,7 @@ function Header({ className }: Props) {
         {({ close }) => (
           <ul
             role="menu"
-            className="jumpu-card"
+            className="jumpu-card overflow-y-scroll max-h-[80vh]"
             aria-busy={!consumers}
             onClick={() => close()}
           >
@@ -90,7 +90,7 @@ function Header({ className }: Props) {
         {({ close }) => (
           <ul
             role="menu"
-            className="jumpu-card"
+            className="jumpu-card overflow-y-scroll max-h-[80vh]"
             aria-busy={!portalCategories}
             onClick={() => close()}
           >
@@ -125,7 +125,11 @@ function Header({ className }: Props) {
       </Popover>
       <Popover className="hidden lg:block" title="OKUTEPについて">
         {({ close }) => (
-          <ul role="menu" className="jumpu-card" onClick={() => close()}>
+          <ul
+            role="menu"
+            className="jumpu-card overflow-y-scroll max-h-[80vh]"
+            onClick={() => close()}
+          >
             {contents.map((content) => (
               <li key={content.slug} role="menuitem">
                 <Link href={pagesPath._slug(content.slug).$url()}>


### PR DESCRIPTION
最大高さを設定しスクロールしてもらうことで対処