### PR TITLE
refactor: コードの整理

### DIFF
--- a/frontend/lib/use-portal-categories.ts
+++ b/frontend/lib/use-portal-categories.ts
@@ -2,7 +2,7 @@ import useSWRImmutable from "swr/immutable";
 import { client } from "lib/client";
 import { PortalCategory } from "api/@types";
 
-const key = "portal_category/list" as const;
+const key = "portalCategory/list" as const;
 
 async function fetcher(_: typeof key) {
   return client.portalCategory.list.$get();

--- a/frontend/lib/use-wisdom-badges-consumers.ts
+++ b/frontend/lib/use-wisdom-badges-consumers.ts
@@ -2,7 +2,7 @@ import useSWRImmutable from "swr/immutable";
 import { client } from "lib/client";
 import { Consumer } from "api/@types";
 
-const key = "wisdom-badges/consumer/list" as const;
+const key = "wisdomBadges/consumer/list" as const;
 
 async function fetcher(_: typeof key, badgesId: number) {
   return client.wisdomBadges.consumer.list.$get({

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -10,7 +10,7 @@ export type Context = {
 export type Props = {
   keyword: string;
   wisdomBadgesList: Awaited<
-    ReturnType<typeof client.portalCategory.badges.list.$get>
+    ReturnType<typeof client.wisdomBadges.list.keyword.$get>
   >;
 };
 


### PR DESCRIPTION
- swr のキーの命名規則の統一
- 参照する型が結果的に同じだが実体が不一致