### PR TITLE
fix: デプロイ時 Docker コンテナー名が衝突している

### DIFF
--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -12,6 +12,7 @@ fi
 readonly FRONTEND_DIR="${CHECKOUT_DIR}frontend"
 cd $FRONTEND_DIR
 docker build -t frontend .
+docker container stop frontend
 docker run --rm -p 3000:3000 --name frontend --net app_network --detach frontend
 # backend
 readonly BACKEND_DIR="${CHECKOUT_DIR}backend"


### PR DESCRIPTION
以下への対応

> err: docker: Error response from daemon: Conflict. The container name "/frontend" is already in use by container "8ecccd086591eb2451b837ba33b400360208b30681369c3bb7c74184eb218f10". You have to remove (or rename) that container to be able to reuse that name.

https://github.com/npocccties/chiloportal/actions/runs/3341623209/jobs/5533016280#step:3:4479