### PR TITLE
fix: issuer の URL のフォーマットが無効のとき描画に失敗する

### DIFF
--- a/frontend/components/WisdomBadgesCard.tsx
+++ b/frontend/components/WisdomBadgesCard.tsx
@@ -2,13 +2,14 @@ import Link from "next/link";
 import Image from "next/future/image";
 import { BadgeDetail2 } from "api/@types";
 import { pagesPath } from "lib/$path";
-import { NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH } from "lib/env";
+import { getImageUrl } from "lib/issuer";
 
 type Props = {
   wisdomBadges: BadgeDetail2;
 };
 
 function WisdomBadgesCard({ wisdomBadges }: Props) {
+  const url = getImageUrl(wisdomBadges.issuer_url);
   return (
     <Link
       href={pagesPath.wisdom_badges
@@ -43,17 +44,9 @@ function WisdomBadgesCard({ wisdomBadges }: Props) {
               NOTE: 事前に許可したホスト以外画像最適化の対象にできない
               See Also: https://nextjs.org/docs/messages/next-image-unconfigured-host
             */}
-            <img
-              src={
-                new URL(
-                  NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH,
-                  wisdomBadges.issuer_url
-                ).href
-              }
-              width={20}
-              height={20}
-              alt=""
-            />
+            {typeof url === "string" && (
+              <img src={url} width={20} height={20} alt="" />
+            )}
             <span className="font-bold mr-1">{wisdomBadges.issuer_name}</span>
             <span className="text-gray-500">発行</span>
           </p>

--- a/frontend/components/WisdomBadgesItem.tsx
+++ b/frontend/components/WisdomBadgesItem.tsx
@@ -2,13 +2,14 @@ import Link from "next/link";
 import Image from "next/future/image";
 import { BadgeDetail2 } from "api/@types";
 import { pagesPath } from "lib/$path";
-import { NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH } from "lib/env";
+import { getImageUrl } from "lib/issuer";
 
 type Props = {
   wisdomBadges: BadgeDetail2;
 };
 
 function WisdomBadgesItem({ wisdomBadges }: Props) {
+  const url = getImageUrl(wisdomBadges.issuer_url);
   return (
     <Link
       href={pagesPath.wisdom_badges
@@ -33,17 +34,9 @@ function WisdomBadgesItem({ wisdomBadges }: Props) {
               NOTE: 事前に許可したホスト以外画像最適化の対象にできない
               See Also: https://nextjs.org/docs/messages/next-image-unconfigured-host
             */}
-            <img
-              src={
-                new URL(
-                  NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH,
-                  wisdomBadges.issuer_url
-                ).href
-              }
-              width={20}
-              height={20}
-              alt=""
-            />
+            {typeof url === "string" && (
+              <img src={url} width={20} height={20} alt="" />
+            )}
             <span className="font-bold mr-1">{wisdomBadges.issuer_name}</span>
             <span className="text-gray-500">発行</span>
           </p>

--- a/frontend/lib/issuer.ts
+++ b/frontend/lib/issuer.ts
@@ -1,0 +1,14 @@
+import { NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH } from "lib/env";
+
+/**
+ * バッジ発行者の画像の URL を返す変数
+ * @params url バッジ発行者の URL
+ * @returns 画像の URL
+ */
+export function getImageUrl(url: string): string | Error {
+  try {
+    return new URL(NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH, url).href;
+  } catch (e) {
+    return e instanceof Error ? e : new Error(String(e));
+  }
+}


### PR DESCRIPTION
URL コンストラクターが例外を投げていることが原因
例外処理を追加することで対処