### PR TITLE
chore: set-output の \$GITHUB_OUTPUT への移行

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: true
         run: |
           corepack yarn format
-          echo "::set-output name=status::$(git status --porcelain)"
+          echo "status=$(git status --porcelain)" >> $GITHUB_OUTPUT
       - if: steps.format.outputs.status != ''
         run: |
           git -c "user.name=github-actions[bot]" -c "user.email=github-actions[bot]@users.noreply.github.com" commit -a -m "bot: format"


### PR DESCRIPTION
resolve #391

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/