### PR TITLE
chore: 整形対象外のファイルの追加

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,5 @@
 .pnp.*
 .yarn
 api
+lib/$path.ts
+public/mockServiceWorker.js


### PR DESCRIPTION
いずれもmsw、pathpidaによって生成されるファイルであるため