### PR TITLE
chore: .env{,.production} を Git 管理対象外にする

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -26,7 +26,9 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env*.local
+.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
本番デプロイに利用する想定のため