### PR TITLE
chore: build.sh の実行時に他のディレクトリにいると Dockerfile が見つからないとエラーが発生するので、他のディレ…

### DIFF
--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+echo $0
+DIR=$(cd $(dirname $0); pwd)
+echo $DIR
+cd $DIR
+
 docker build -t frontend .
 docker container stop frontend 2>&1 || true
 docker run --rm -p 3000:3000 --name frontend --net app_network --detach frontend


### PR DESCRIPTION
…クトリからも実行できるよう、カレントディレクトリを frontend に移動するようにした