### PR TITLE
chore: .env.test をリポジトリから取り除くように

### DIFF
--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_API_MOCKING=false
-NEXT_PUBLIC_API_BASE_URL=https://portal.example.org/api/v1/
-NEXT_PUBLIC_MOODLE_DASHBOARD_URL=https://lms.example.org/my/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 .env
 .env*.local
 .env.production
+.env.test
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,7 +32,7 @@ corepack yarn start # テストサーバーの起動
 ### Docker 環境
 
 ```shell
-cp .env.development .env # 環境変数の用意 (コピー元ファイルは .env.test でも可)
+cp .env.development .env # 環境変数の用意 (別途 .env.test 作成でも可)
 docker build -t frontend . # Docker イメージのビルド
 docker run --rm -p 3000:3000 frontend # Docker コンテナの起動
 ```


### PR DESCRIPTION
テスト用環境変数を参照利用する必要が引き続きあるが
リポジトリにテスト用の値を含めないという方針になったため