### PR TITLE
fix: /stage/field/list のAPIで重複する能力バッジIDを排除する（categorised_badges で同一の能…

### DIFF
--- a/backend/chiloportal/responses.py
+++ b/backend/chiloportal/responses.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from .enums import *
+from .utils import *
 
 
 def to_portal_categories(queryset):
@@ -208,7 +209,7 @@ def _to_field_detail(field_dict, field1key, field2keys, wisdom_dict):
         if not field2key.startswith(field1key):
             continue
         fields = sorted(field_dict[field2key], key=lambda f: f.sort_key)
-        wisdom_badge_id_array = sorted(wisdom_dict[field2key])
+        wisdom_badge_id_array = sorted(distinct_list(wisdom_dict[field2key]))
         field3_array = []
         for field in fields:
             field3_array.append(

--- a/backend/chiloportal/utils.py
+++ b/backend/chiloportal/utils.py
@@ -5,3 +5,6 @@ def is_int(s):
         return False
     else:
         return True
+
+def distinct_list(lst):
+    return list(set(lst))


### PR DESCRIPTION
…力バッジを参照すると重複IDが発生し、クライアントに悪影響を及ぼすため）