### PR TITLE
fix: 指標項目別能力バッジの集計処理が意図しない配列のネストになっている

### DIFF
--- a/frontend/pages/consumers/[consumerId]/frameworks/[frameworkId]/stages/[stageId].tsx
+++ b/frontend/pages/consumers/[consumerId]/frameworks/[frameworkId]/stages/[stageId].tsx
@@ -27,7 +27,7 @@ export type Props = {
   stages: Stage[];
   stage: Stage;
   field: FieldDetail;
-  wisdomBadgesListPerFields3PerField1: (BadgeDetail1 | BadgeDetail2)[][][];
+  wisdomBadgesListPerFields3: (BadgeDetail1 | BadgeDetail2)[][];
 };
 
 export async function getServerSideProps({
@@ -50,18 +50,16 @@ export async function getServerSideProps({
     const field = await client.stage.field.list.$get({
       query: { stage_id: Number(stageId) },
     });
-    const wisdomBadgesListPerFields3PerField1 = await Promise.all(
+    const wisdomBadgesListPerFields3 = await Promise.all(
       field.field1.flatMap(({ field2 }) =>
         field2.flatMap(({ field3 }) =>
-          Promise.all(
-            field3.map(({ wisdom_badges }) =>
-              client.badges.$get({
-                query: {
-                  badges_type: "wisdom",
-                  badges_ids: wisdom_badges.join(","),
-                },
-              })
-            )
+          field3.flatMap(({ wisdom_badges }) =>
+            client.badges.$get({
+              query: {
+                badges_type: "wisdom",
+                badges_ids: wisdom_badges.join(","),
+              },
+            })
           )
         )
       )
@@ -73,7 +71,7 @@ export async function getServerSideProps({
         stages,
         stage,
         field,
-        wisdomBadgesListPerFields3PerField1,
+        wisdomBadgesListPerFields3,
       },
     };
   } catch (e) {

--- a/frontend/templates/Stage.tsx
+++ b/frontend/templates/Stage.tsx
@@ -15,7 +15,7 @@ export default function Stage({
   stages,
   stage,
   field,
-  wisdomBadgesListPerFields3PerField1,
+  wisdomBadgesListPerFields3,
 }: Props) {
   const { open, onOpen, onClose } = useDialog();
   return (
@@ -121,13 +121,13 @@ export default function Stage({
                       {field3_name}
                     </h4>
                     <ul>
-                      {wisdomBadgesListPerFields3PerField1[field1Index][
-                        field3Index
-                      ].map((wisdomBadges) => (
-                        <li className="mb-8" key={wisdomBadges.badges_id}>
-                          <WisdomBadgesItem wisdomBadges={wisdomBadges} />
-                        </li>
-                      ))}
+                      {wisdomBadgesListPerFields3[field3Index].map(
+                        (wisdomBadges) => (
+                          <li className="mb-8" key={wisdomBadges.badges_id}>
+                            <WisdomBadgesItem wisdomBadges={wisdomBadges} />
+                          </li>
+                        )
+                      )}
                     </ul>
                   </section>
                 ))}


### PR DESCRIPTION
どの箇所で flatMap すべきか、あるいは Promise.all で配列を得るべきかの
検討不足によるもの
この修正によって指標項目の内容に応じてクライアント側での
例外が発生する場合がある現象の改善が期待されます