### PR TITLE
feat: 空文字列での検索は許容しない

### DIFF
--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -38,6 +38,7 @@ function SearchForm({ className, size = "medium" }: Props) {
           { ["text-lg"]: size === "large" }
         )}
         type="submit"
+        disabled={keyword.trim().length === 0}
         onClick={handleClick}
       >
         検索

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -2,6 +2,7 @@ import { GetServerSidePropsResult } from "next";
 import Error from "next/error";
 import { client, getErrorProps } from "lib/client";
 import Template from "templates/Search";
+import { pagesPath } from "lib/$path";
 
 export type Query = { q?: string; p?: string };
 
@@ -26,22 +27,16 @@ export async function getServerSideProps({
 }: Context): Promise<GetServerSidePropsResult<ErrorProps | Props>> {
   try {
     const pageNumber = Number(p);
-    const wisdomBadgesList =
-      q.length > 0
-        ? await client.wisdomBadges.list.keyword.$get({
-            query: {
-              keyword: q,
-              page_number: Number.isInteger(pageNumber)
-                ? pageNumber
-                : undefined,
-            },
-          })
-        : {
-            badges: [],
-            total_count: 0,
-            start: 0,
-            end: 0,
-          };
+    if (q.trim().length === 0)
+      return {
+        redirect: { destination: pagesPath.$url().pathname, permanent: false },
+      };
+    const wisdomBadgesList = await client.wisdomBadges.list.keyword.$get({
+      query: {
+        keyword: q,
+        page_number: Number.isInteger(pageNumber) ? pageNumber : undefined,
+      },
+    });
 
     return {
       props: { keyword: q, wisdomBadgesList },


### PR DESCRIPTION
resolve #510

以下の変更によって対処

- UI として検索可能にしない
- 直接 URL にアクセスした場合ポータルトップにリダイレクトする