### PR TITLE
fix: チャットがグローバルメニューヘッダーより下に重なる

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -12,7 +12,7 @@ function Layout({ children }: Props) {
       <Header className="sticky z-20 top-0 left-0 w-full" />
       {children}
       <Footer />
-      <Chat className="fixed bottom-0 right-[10vw]" />
+      <Chat className="fixed z-20 bottom-0 right-[10vw]" />
     </div>
   );
 }


### PR DESCRIPTION
特定のビューポートサイズかつタッチスクリーンでの操作で
チャットを閉じるボタンへアクセス不能になる場合があるため
上に重なることが操作上望ましいように思った