### PR TITLE
fix: ポータルカテゴリーの画像について端の見切れが生じる

### DIFF
--- a/frontend/templates/PortalCategory.tsx
+++ b/frontend/templates/PortalCategory.tsx
@@ -23,7 +23,6 @@ export default function PortalCategory({
       />
       <header className="flex gap-8 items-center mb-16">
         <Image
-          className="rounded-2xl"
           src={`/images/${portalCategory.image_url_path}`}
           width={200}
           height={200}


### PR DESCRIPTION
見た目更新前の角丸の見た目が残っていることが原因
角丸の見た目を取り止めることで対処