### PR TITLE
feat: 発行機関を一覧するAPIの実装

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -20,7 +20,7 @@ COPY frontend/schemas/ ./schemas
 COPY frontend/styles/ ./styles
 COPY frontend/templates/ ./templates
 COPY backend/doc/openapi.yaml /backend/doc/openapi.yaml
-RUN echo "7622f5b529f8d54eae786d25cbcd2378  ../backend/doc/openapi.yaml" > md5sum.txt && md5sum -c md5sum.txt
+RUN echo "a28007cb5fed131cc1598a6e72f5b726  ../backend/doc/openapi.yaml" > md5sum.txt && md5sum -c md5sum.txt
 RUN corepack yarn build
 
 FROM base as install

--- a/backend/chiloportal/responses.py
+++ b/backend/chiloportal/responses.py
@@ -29,6 +29,16 @@ def to_consumer(consumer):
         "email": consumer.email,
     }
 
+def to_issuers(queryset):
+    return [to_issuer(issuer) for issuer in queryset]
+
+def to_issuer(issuer):
+    return {
+        "issuer_id": issuer.id,
+        "name": issuer.name,
+        "url": issuer.url,
+        "email": issuer.email,
+    }
 
 def to_criteria(criteria):
     return {

--- a/backend/chiloportal/tests/views/localhost/base_api_view_tests.py
+++ b/backend/chiloportal/tests/views/localhost/base_api_view_tests.py
@@ -10,6 +10,7 @@ class BaseAPIViewTests(TestCase):
     base_url = "http://localhost:8000"
     consumer_detail_url = urljoin(base_url, "consumer/")
     consumer_list_url = urljoin(base_url, "consumer/list/")
+    issuer_list_url = urljoin(base_url, "issuer/list/")
     stage_field_list_url = urljoin(base_url, "stage/field/list/")
     portal_category_list_url = urljoin(base_url, "portalCategory/list/")
     portal_category_badge_list_url = urljoin(base_url, "portalCategory/badges/list/")
@@ -622,6 +623,20 @@ class BaseAPIViewTests(TestCase):
         self.assertEqual(data["name"], consumer.name)
         self.assertEqual(data["url"], consumer.url)
         self.assertEqual(data["email"], consumer.email)
+
+    def assert_issuers(self, array, expect_array):
+        self.assertEqual(len(array), len(expect_array))
+        i = 0
+        for issuer in expect_array:
+            data = array[i]
+            self.assert_issuer(data, issuer)
+            i += 1
+
+    def assert_issuer(self, data, issuer):
+        self.assertEqual(data["issuer_id"], issuer.id)
+        self.assertEqual(data["name"], issuer.name)
+        self.assertEqual(data["url"], issuer.url)
+        self.assertEqual(data["email"], issuer.email)
 
     def assert_field(
         self, field1, field2, field3, expect_field, expect_wisdom_badge_id_list=None

--- a/backend/chiloportal/tests/views/localhost/test_issuer_list.py
+++ b/backend/chiloportal/tests/views/localhost/test_issuer_list.py
@@ -1,0 +1,26 @@
+from rest_framework.test import APIRequestFactory
+from .base_api_view_tests import BaseAPIViewTests
+from ....views import *
+
+
+class IssuerListTests(BaseAPIViewTests):
+    def test_issuer_list_200(self):
+        factory = APIRequestFactory()
+        view = IssuerList.as_view()
+        self.create_test_relation_data()
+        response = self.request_normal(factory, view, self.issuer_list_url)
+        self.assert_issuers(
+            response.data, [iss for iss in Issuer.objects.all().order_by("pk")]
+        )
+
+    def test_issuer_list_200_many(self):
+        factory = APIRequestFactory()
+        view = IssuerList.as_view()
+        issuers = self.create_test_issuer_data(self.test_data_count)
+        response = self.request_normal(factory, view, self.issuer_list_url)
+        self.assert_issuers(response.data, issuers)
+
+    def test_issuer_list_200_zero(self):
+        factory = APIRequestFactory()
+        view = IssuerList.as_view()
+        self.request_normal_zero_array(factory, view, self.issuer_list_url, {})

--- a/backend/chiloportal/urls.py
+++ b/backend/chiloportal/urls.py
@@ -35,6 +35,7 @@ schema_view = get_schema_view(
 urlpatterns = [
     path("consumer/", ConsumerDetail.as_view(), name="consumer-detail"),
     path("consumer/list/", ConsumerList.as_view(), name="consumer-list"),
+    path("issuer/list/", IssuerList.as_view(), name="issuer-list"),
     path("stage/field/list/", StageFieldList.as_view(), name="stage-field-list"),
     path(
         "portalCategory/list/", PortalCategoryList.as_view(), name="portalCategory-list"

--- a/backend/chiloportal/views/__init__.py
+++ b/backend/chiloportal/views/__init__.py
@@ -1,5 +1,6 @@
 from .consumer_detail import *
 from .consumer_list import *
+from .issuer_list import *
 from .stage_field_list import *
 from .portal_category_list import *
 from .portal_category_badges_list import *

--- a/backend/chiloportal/views/issuer_list.py
+++ b/backend/chiloportal/views/issuer_list.py
@@ -1,0 +1,15 @@
+from rest_framework.response import Response
+from rest_framework.exceptions import NotFound, ParseError
+from ..models import *
+from .. import utils
+from ..swagger import *
+from ..responses import *
+from .base_api_view import *
+
+
+class IssuerList(BaseAPIView):
+    def _get(self, request):
+        queryset = Issuer.objects.all().order_by("pk")
+        if queryset.exists() == False:
+            return Response([])
+        return Response(to_issuers(queryset))

--- a/backend/doc/openapi.yaml
+++ b/backend/doc/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Portal Badges API
   description: 教員研修システム向けバッジ関連データ取得API
-  version: 0.9.7
+  version: 0.9.8
 servers:
   - url: https://chiloportal.example.com/api/v1
 tags:
@@ -70,6 +70,21 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Consumer'
+  /issuer/list:
+    get:
+      tags:
+        - issuer list
+      description: 登録されている発行機関を一覧で返却します
+      operationId: findIssuerList
+      responses:
+        '200':
+          description: successful opperation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Issuer'
   /stage/field/list:
     get:
       tags:
@@ -419,6 +434,28 @@ components:
       additionalProperties: false
       required:
         - consumer_id
+        - name
+        - url
+        - email
+    Issuer:
+      type: object
+      properties:
+        issuer_id:
+          type: integer
+          format: int64
+          example: 101
+        name:
+          type: string
+          example: issuer101
+        url:
+          type: string
+          example: https://example.com/issuer101/
+        email:
+          type: string
+          example: issuer101@example.com
+      additionalProperties: false
+      required:
+        - issuer_id
         - name
         - url
         - email

--- a/frontend/mocks/faker.ts
+++ b/frontend/mocks/faker.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import {
   Consumer,
+  Issuer,
   FieldDetail,
   PortalCategory,
   BadgeDetail1,
@@ -13,6 +14,13 @@ import {
 
 export const consumer = (): Consumer => ({
   consumer_id: faker.datatype.number(),
+  name: faker.company.name(),
+  url: faker.internet.url(),
+  email: faker.internet.email(),
+});
+
+export const issuer = (): Issuer => ({
+  issuer_id: faker.datatype.number(),
   name: faker.company.name(),
   url: faker.internet.url(),
   email: faker.internet.email(),

--- a/frontend/mocks/handlers.ts
+++ b/frontend/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import { client } from "lib/client";
 import {
   consumer,
+  issuer,
   field,
   portalCategory,
   wisdomBadges,
@@ -16,6 +17,9 @@ export const handlers = [
   http.get(client.consumer.$path(), () => HttpResponse.json(consumer())),
   http.get(client.consumer.list.$path(), () =>
     HttpResponse.json([...Array(10)].map(consumer)),
+  ),
+  http.get(client.issuer.list.$path(), () =>
+    HttpResponse.json([...Array(10)].map(issuer)),
   ),
   http.get(client.stage.field.list.$path(), () => HttpResponse.json(field())),
   http.get(client.portalCategory.list.$path(), () =>


### PR DESCRIPTION
ref #680 #681 #683

以下の方法で追加分のテストをパスすることを確認。

```
cd backend
cp .env.localhost .env
cp docker-compose.localhost.yml docker-compose.yml
docker compose up
docker compose exec app pytest
```

また、Django管理画面よりデータを追加して期待するレスポンスが得られることを確認。