### PR TITLE
fix: p クエリパラメーター未指定時全件のバッジが画面に表示される

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -115,7 +115,7 @@ function Chat({ className }: Props) {
     try {
       const { badges: badgesList, total_count } =
         await client.wisdomBadges.list.keyword.$get({
-          query: { keyword },
+          query: { keyword, page_number: 1 },
         });
       popChat();
       total_count === 0

--- a/frontend/mocks/faker.ts
+++ b/frontend/mocks/faker.ts
@@ -139,3 +139,21 @@ export const consumerBadge = (): ConsumerBadge => ({
   wisdom_badges_description: faker.lorem.paragraph(),
   knowledge_badges_count: faker.datatype.number(),
 });
+
+export const paginatedWisdomBadges = (
+  pageNumber?: number,
+): {
+  badges: BadgeDetail1[];
+  total_count: number;
+  start: number;
+  end: number;
+} => {
+  const perPage = 30;
+  const totalCount = 3000;
+  return {
+    badges: [...Array(pageNumber ? perPage : totalCount)].map(wisdomBadges),
+    total_count: totalCount,
+    start: perPage * ((pageNumber ?? 1) - 1) + 1,
+    end: pageNumber ? Math.min(perPage * pageNumber, totalCount) : totalCount,
+  };
+};

--- a/frontend/mocks/handlers.ts
+++ b/frontend/mocks/handlers.ts
@@ -11,6 +11,7 @@ import {
   stage,
   consumerGoal,
   consumerBadge,
+  paginatedWisdomBadges,
 } from "./faker";
 
 export const handlers = [
@@ -26,15 +27,9 @@ export const handlers = [
     HttpResponse.json([...Array(10)].map(portalCategory)),
   ),
   http.get(client.portalCategory.badges.list.$path(), ({ request }) => {
-    const perPage = 30;
     const url = new URL(request.url);
     const pageNumber = Number(url.searchParams.get("page_number") ?? 1);
-    return HttpResponse.json({
-      badges: [...Array(30)].map(wisdomBadges),
-      total_count: 3000,
-      start: perPage * (pageNumber - 1) + 1,
-      end: perPage * pageNumber,
-    });
+    return HttpResponse.json(paginatedWisdomBadges(pageNumber));
   }),
   http.get(client.framework.$path(), () => HttpResponse.json(framework())),
   http.get(client.framework.stage.list.$path(), () =>
@@ -53,26 +48,14 @@ export const handlers = [
     }
   }),
   http.get(client.badges.list.$path(), ({ request }) => {
-    const perPage = 30;
     const url = new URL(request.url);
-    const pageNumber = Number(url.searchParams.get("page_number") ?? 1);
-    return HttpResponse.json({
-      badges: [...Array(30)].map(wisdomBadges),
-      total_count: 3000,
-      start: perPage * (pageNumber - 1) + 1,
-      end: perPage * pageNumber,
-    });
+    const pageNumber = Number(url.searchParams.get("page_number"));
+    return HttpResponse.json(paginatedWisdomBadges(pageNumber));
   }),
   http.get(client.wisdomBadges.list.keyword.$path(), ({ request }) => {
-    const perPage = 30;
     const url = new URL(request.url);
-    const pageNumber = Number(url.searchParams.get("page_number") ?? 1);
-    return HttpResponse.json({
-      badges: [...Array(30)].map(wisdomBadges),
-      total_count: 3000,
-      start: perPage * (pageNumber - 1) + 1,
-      end: perPage * pageNumber,
-    });
+    const pageNumber = Number(url.searchParams.get("page_number"));
+    return HttpResponse.json(paginatedWisdomBadges(pageNumber));
   }),
   http.get(client.wisdomBadges.consumer.list.$path(), () =>
     HttpResponse.json([...Array(10)].map(consumer)),

--- a/frontend/pages/portal_categories/[portalCategoryId].tsx
+++ b/frontend/pages/portal_categories/[portalCategoryId].tsx
@@ -44,7 +44,7 @@ export async function getServerSideProps({
     const wisdomBadgesList = await client.portalCategory.badges.list.$get({
       query: {
         portal_category_id: portalCategory.portal_category_id,
-        page_number: Number.isInteger(pageNumber) ? pageNumber : undefined,
+        page_number: Number.isInteger(pageNumber) ? pageNumber : 1,
       },
     });
     return {

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -36,7 +36,7 @@ export async function getServerSideProps({
     const wisdomBadgesList = await client.wisdomBadges.list.keyword.$get({
       query: {
         keyword: q,
-        page_number: Number.isInteger(pageNumber) ? pageNumber : undefined,
+        page_number: Number.isInteger(pageNumber) ? pageNumber : 1,
       },
     });
 


### PR DESCRIPTION
resolve #776
API の振る舞いとして page_number クエリパラメーター未指定時
ページネーションせず全件のバッジが返却される実装になっており
フロントエンドの実装として考慮していない点に対応します