### PR TITLE
fix: 無効な stage_id が /framework/stage/list に渡されうる

### DIFF
--- a/frontend/pages/discover.tsx
+++ b/frontend/pages/discover.tsx
@@ -174,7 +174,7 @@ export async function getServerSideProps({
       if (!stage)
         return { props: { title: "Stage Not Found", statusCode: 404 } };
       const field = await client.stage.field.list.$get({
-        query: { stage_id: Number(query.stage_id) },
+        query: { stage_id: Number(stage.stage_id) },
       });
       const badges = await Promise.all(
         field.field1.flatMap(({ field2 }) =>


### PR DESCRIPTION
resolve #807

誤ってフロントエンドで受け取るクエリパラメーターを使用していることが原因