### PR TITLE
fix: 読み取り権限のないファイルをビルドコンテキストに含めようとして失敗する 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+backend/ssl_certs
 frontend/.env.*
 !frontend/.env.production
 frontend/node_modules


### PR DESCRIPTION
.dockerignore に追記してビルドコンテキストから除外することで対処