### PR TITLE
feat(WisdomBadgesItem): ホバーの見た目は文字色のみで表現する

### DIFF
--- a/frontend/components/WisdomBadgesItem.tsx
+++ b/frontend/components/WisdomBadgesItem.tsx
@@ -17,7 +17,7 @@ function WisdomBadgesItem({ wisdomBadges }: Props) {
       href={pagesPath.wisdom_badges
         ._wisdomBadgesId(wisdomBadges.badges_id)
         .$url()}
-      className="p-1.5 pr-2 flex items-center gap-4 hover:bg-gray-100"
+      className="p-1.5 pr-2 flex items-center gap-4 text-gray-700 hover:text-black"
     >
       <Image
         src={`/images/${wisdomBadges.image}`}


### PR DESCRIPTION
https://www.figma.com/file/dCE06JShf29eqnvZ4vcE8U/OZONE-edu?type=design&node-id=3006-9143&mode=design&t=R1L7LpisJuW4JjCY-4 の指定にあわせて見た目を更新します:

> https://dev-portal.oku.cccties.org/discover
> 
> を見ると、hover時に背景色が変わっているが、面積が多く空白が多い場合はなるべくこの方法を避けたい。
> 
> 少し控えめな変化でhover対応したいので、text-gray-700 hover:text-black で進めたい。