### PR TITLE
feat: ページヘッダーとコンテンツの余白の調整

### DIFF
--- a/frontend/templates/Issuer.tsx
+++ b/frontend/templates/Issuer.tsx
@@ -32,7 +32,7 @@ export default function Issuer({
         />
       </div>
       <Container className="relative">
-        <header className="flex items-end gap-4 -mt-16 md:-mt-[7.5rem] mb-4">
+        <header className="flex items-end gap-4 -mt-16 md:-mt-[7.5rem] mb-6">
           {/* eslint-disable @next/next/no-img-element */}
           {/*
         NOTE: 事前に許可したホスト以外画像最適化の対象にできない

--- a/frontend/templates/Issuer.tsx
+++ b/frontend/templates/Issuer.tsx
@@ -32,7 +32,7 @@ export default function Issuer({
         />
       </div>
       <Container className="relative">
-        <header className="flex items-end gap-4 -mt-16 md:-mt-[7.5rem] mb-6">
+        <header className="flex items-end gap-4 -mt-16 md:-mt-[7.5rem] mb-6 md:mb-10">
           {/* eslint-disable @next/next/no-img-element */}
           {/*
         NOTE: 事前に許可したホスト以外画像最適化の対象にできない
@@ -47,7 +47,7 @@ export default function Issuer({
               alt=""
             />
           )}
-          <h1 className="text-lg md:text-2xl font-bold pb-1 md:pb-6">
+          <h1 className="text-xl md:text-3xl font-bold pb-0 md:pb-2 md:pl-4">
             {issuer.name}
           </h1>
         </header>


### PR DESCRIPTION
以下に対応します

> モバイル時、大学のロゴが入らないと判断むずかしいですが、ロゴと見出しの間が近づきすぎになっているように見えます。

<img width="503" alt="attachment" src="https://github.com/npocccties/chiloportal/assets/9744580/f6bb57cc-80c9-47fa-a995-659a7d29ecad">

https://www.figma.com/file/dCE06JShf29eqnvZ4vcE8U?node-id=2219:12004&mode=design#721413182