### PR TITLE
fix: 意図しないサイズで大学ロゴが表示される

### DIFF
--- a/frontend/templates/WisdomBadges.tsx
+++ b/frontend/templates/WisdomBadges.tsx
@@ -71,7 +71,7 @@ export default function WisdomBadges({
       */}
               {typeof url === "string" && (
                 <img
-                  className="rounded-xl bg-white object-contain p-1"
+                  className="rounded-xl bg-white object-contain p-1 size-[34px]"
                   src={url}
                   width={34}
                   height={34}


### PR DESCRIPTION
CSS によって明示的に縦横サイズを指定することで対処