### PR TITLE
fix: 無効な値をキーワード検索APIに渡しうる

### DIFF
--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -21,7 +21,7 @@ export type Props = {
   keyword: string;
   wisdomBadgesList: Awaited<
     ReturnType<typeof client.wisdomBadges.list.keyword.$get>
-  >;
+  > | null;
 };
 
 export async function getServerSideProps({
@@ -29,12 +29,14 @@ export async function getServerSideProps({
 }: Context): Promise<GetServerSidePropsResult<ErrorProps | Props>> {
   try {
     const pageNumber = parsePageQuery(p);
-    const wisdomBadgesList = await client.wisdomBadges.list.keyword.$get({
-      query: {
-        keyword: q,
-        page_number: pageNumber,
-      },
-    });
+    const wisdomBadgesList = q
+      ? await client.wisdomBadges.list.keyword.$get({
+          query: {
+            keyword: q,
+            page_number: pageNumber,
+          },
+        })
+      : null;
 
     return {
       props: { keyword: q, wisdomBadgesList },

--- a/frontend/templates/Search.tsx
+++ b/frontend/templates/Search.tsx
@@ -20,7 +20,7 @@ export default function Search({ keyword, wisdomBadgesList }: Props) {
       />
       <header className="mb-6">
         <h1 className="text-2xl text-gray-700 mb-4">キーワード検索</h1>
-        {keyword && (
+        {keyword && wisdomBadgesList && (
           <p className="mb-6">
             「{keyword}」に関連する能力バッジが{wisdomBadgesList.total_count}
             件あります
@@ -32,19 +32,23 @@ export default function Search({ keyword, wisdomBadgesList }: Props) {
           variant="light"
         />
       </header>
-      <ul className="mb-8">
-        {wisdomBadgesList.badges.map((wisdomBadges) => (
-          <li key={wisdomBadges.badges_id}>
-            <WisdomBadgesItem wisdomBadges={wisdomBadges} />
-          </li>
-        ))}
-      </ul>
-      <Pagination
-        totalCount={wisdomBadgesList.total_count}
-        start={wisdomBadgesList.start}
-        end={wisdomBadgesList.end}
-        handleHref={handleHref}
-      />
+      {wisdomBadgesList && (
+        <>
+          <ul className="mb-8">
+            {wisdomBadgesList.badges.map((wisdomBadges) => (
+              <li key={wisdomBadges.badges_id}>
+                <WisdomBadgesItem wisdomBadges={wisdomBadges} />
+              </li>
+            ))}
+          </ul>
+          <Pagination
+            totalCount={wisdomBadgesList.total_count}
+            start={wisdomBadgesList.start}
+            end={wisdomBadgesList.end}
+            handleHref={handleHref}
+          />
+        </>
+      )}
     </Container>
   );
 }


### PR DESCRIPTION
検索キーワードが空文字列の場合はAPIリクエストしないことで対処