### PR TITLE
fix: 学びを探すの教員育成指標のステージが切り替わらない

### DIFF
--- a/frontend/templates/Discover.tsx
+++ b/frontend/templates/Discover.tsx
@@ -152,7 +152,7 @@ function Framework(props: FrameworkBadges) {
                     by: "framework",
                     consumer_id: String(props.consumer.consumer_id),
                     framework_id: String(props.framework.framework_id),
-                    stage_id: String(props.stage.stage_id),
+                    stage_id: String(stage.stage_id),
                   },
                 })}
               >


### PR DESCRIPTION
fix #849