### PR TITLE
fix: NEXT_PUBLIC_API_PER_PAGE 未指定時初期値が使用されない

### DIFF
--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -8,8 +8,9 @@ export const NEXT_PUBLIC_API_MOCKING: boolean = yn(
 );
 export const NEXT_PUBLIC_API_BASE_URL: string =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
-export const NEXT_PUBLIC_API_PER_PAGE: number =
-  Number(process.env.NEXT_PUBLIC_API_PER_PAGE) ?? 30;
+export const NEXT_PUBLIC_API_PER_PAGE: number = Number(
+  process.env.NEXT_PUBLIC_API_PER_PAGE ?? 30,
+);
 export const NEXT_PUBLIC_BASE_URL: string =
   process.env.NEXT_PUBLIC_BASE_URL ?? "https://portal.example.org/";
 export const NEXT_PUBLIC_MOODLE_DASHBOARD_URL: string =


### PR DESCRIPTION
Number(underined) ?? 30 の前者は nullish ではないことに起因

> NEXT_PUBLIC_API_PER_PAGE 未指定時期待しない値（NaN）が使用される点については別途対応します。

_Originally posted by @knokmki612 in https://github.com/npocccties/chiloportal/issues/847#issuecomment-1990437662_
            