### PR TITLE
feat: md ビューポート幅でも検索欄は表示する

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -91,7 +91,10 @@ function Header({ className }: Props) {
           )}
         </Popover>
         <div className="flex-1" />
-        <SearchForm className="hidden xl:block" size="small" />
+        <SearchForm
+          className="hidden md:w-1/5 md:block xl:w-auto mr-1"
+          size="small"
+        />
         <a
           className="jumpu-outlined-button text-white border-white hover:bg-gray-700 text-sm overflow-hidden whitespace-nowrap text-ellipsis shrink"
           href={NEXT_PUBLIC_MOODLE_DASHBOARD_URL}

--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -23,7 +23,7 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
   return (
     <form
       className={clsx(
-        "inline-flex gap-1 itemc-center relative",
+        "inline-flex gap-1 item-center relative",
         size === "small" && "text-sm",
         size === "large" && "text-lg",
         className,
@@ -41,7 +41,7 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
       <input
         required
         className={clsx(
-          "jumpu-input !rounded-full flex-1 !pl-rel10 mr-2",
+          "jumpu-input !rounded-full w-full !pl-rel10 pr-2",
           variant === "dark" && "bg-black !text-white border-white",
         )}
         type="search"


### PR DESCRIPTION
これによりキーワード検索画面への動線がいずれのビューポートでも提供されます