### PR TITLE
feat: 大学トップ→発行元

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -45,7 +45,7 @@ function Header({ className }: Props) {
           title={
             <>
               <Issuer className="fill-white size-[1.125rem]" alt="" />
-              <span>大学トップ</span>
+              <span>発行元</span>
             </>
           }
         >

--- a/frontend/components/Menu.tsx
+++ b/frontend/components/Menu.tsx
@@ -83,7 +83,7 @@ function Menu({ open, onClose }: Props) {
                 </li>
                 <li>
                   <p className="text-gray-400 font-bold px-rel5 py-rel3">
-                    大学トップ
+                    発行元
                   </p>
                   <ul className="pl-4 mb-3 space-y-1">
                     <Fallback


### PR DESCRIPTION
グローバルメニューの「大学トップ」→「発行元トップ」に用語を揃えた方が良さそう。
発行元が大学とは限らないので。（市町村側がバッジを発行する場合もあると聞いた）

![image](https://github.com/npocccties/oku-private/assets/8957521/ef8f9d0a-c74f-42bd-953a-3578e83189ec)

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/208#issuecomment-1988341204_
            