### PR TITLE
feat: 学びを探す見出しとページコンテンツの関連を境界線で表現する

### DIFF
--- a/frontend/templates/Discover.tsx
+++ b/frontend/templates/Discover.tsx
@@ -222,7 +222,9 @@ export default function Discover({
         nodes={[{ name: "トップ", href: pagesPath.$url() }]}
         leaf="学びを探す"
       />
-      <h1 className="text-3xl font-bold hidden md:block mb-8">学びを探す</h1>
+      <h1 className="text-3xl font-bold hidden md:block mb-8 border-b border-gray-300 pb-2">
+        学びを探す
+      </h1>
       <div
         className="md:grid gap-2"
         style={{


### PR DESCRIPTION
> それでも見た目で気になるのであれば、配置をそのまま、
> タイトルに下線を引くべきでしょう。
> 
> <img width="617" alt="image" src="https://github.com/npocccties/oku-private/assets/281424/6d2da551-a7f3-44e1-aba9-630b620a0a4d">
> 
> このタイミングで検討課題が増えれば開発工数に収まらなくなることも想定して議論させていただけたら助かります。

_Originally posted by @Hidetaro7 in https://github.com/npocccties/oku-private/issues/208#issuecomment-1987437778_
            