### PR TITLE
feat: 検索アイコンは検索ボタンにする

### DIFF
--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { Icon } from "@iconify/react";
 import { useState, useId } from "react";
 import { useRouter } from "next/router";
 import { pagesPath } from "lib/$path";
@@ -34,39 +33,27 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
       <input
         required
         className={clsx(
-          "jumpu-input !rounded-full w-full !pr-rel11",
+          "jumpu-input !rounded-full w-full !pr-rel20",
           variant === "dark" && "bg-black !text-white border-white",
         )}
         type="search"
         name="q"
-        placeholder="学びたいキーワード"
+        placeholder="キーワード"
         onInput={handleInput}
       />
       <button
         type="submit"
         className={clsx(
-          "jumpu-icon-button rounded-full group absolute top-1/2 right-rel1 -translate-y-1/2",
+          "jumpu-outlined-button font-bold text-sm rounded-full absolute top-1/2 right-rel1 -translate-y-1/2 px-rel4 py-rel1",
           size === "small" && "right-rel1",
           size === "medium" && "right-rel2",
           size === "large" && "right-rel3",
-          variant === "dark" && "hover:bg-gray-700",
+          variant === "dark" &&
+            "text-white bg-gray-800 border-gray-600 hover:bg-gray-700",
         )}
         aria-describedby={tooltipId}
       >
-        <Icon
-          className={clsx(
-            variant === "dark" && "text-white",
-            variant === "light" && "text-dark",
-          )}
-          icon="fa-solid:search"
-        />
-        <span
-          id={tooltipId}
-          role="tooltip"
-          className="-translate-x-1/2 !translate-y-[150%] group-hover:-translate-x-1/2 group-hover:translate-y-[150%]"
-        >
-          検索
-        </span>
+        検索
       </button>
     </form>
   );

--- a/frontend/components/SearchForm.tsx
+++ b/frontend/components/SearchForm.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { Icon } from "@iconify/react";
-import { useState } from "react";
+import { useState, useId } from "react";
 import { useRouter } from "next/router";
 import { pagesPath } from "lib/$path";
 
@@ -20,6 +20,7 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
     event.preventDefault();
     router.push(pagesPath.search.$url({ query: { q: keyword } }));
   };
+  const tooltipId = useId();
   return (
     <form
       className={clsx(
@@ -30,18 +31,10 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
       )}
       onSubmit={handleSubmit}
     >
-      <Icon
-        className={clsx(
-          "absolute top-1/2 left-rel4 -translate-y-1/2",
-          variant === "dark" && "text-white",
-          variant === "light" && "text-dark",
-        )}
-        icon="fa-solid:search"
-      />
       <input
         required
         className={clsx(
-          "jumpu-input !rounded-full w-full !pl-rel10 pr-2",
+          "jumpu-input !rounded-full w-full !pr-rel11",
           variant === "dark" && "bg-black !text-white border-white",
         )}
         type="search"
@@ -49,6 +42,32 @@ function SearchForm({ className, size = "medium", variant = "dark" }: Props) {
         placeholder="学びたいキーワード"
         onInput={handleInput}
       />
+      <button
+        type="submit"
+        className={clsx(
+          "jumpu-icon-button rounded-full group absolute top-1/2 right-rel1 -translate-y-1/2",
+          size === "small" && "right-rel1",
+          size === "medium" && "right-rel2",
+          size === "large" && "right-rel3",
+          variant === "dark" && "hover:bg-gray-700",
+        )}
+        aria-describedby={tooltipId}
+      >
+        <Icon
+          className={clsx(
+            variant === "dark" && "text-white",
+            variant === "light" && "text-dark",
+          )}
+          icon="fa-solid:search"
+        />
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className="-translate-x-1/2 !translate-y-[150%] group-hover:-translate-x-1/2 group-hover:translate-y-[150%]"
+        >
+          検索
+        </span>
+      </button>
     </form>
   );
 }


### PR DESCRIPTION
隣接してボタンが配置されている場合、検索欄のボタンに誤認されうる
検索欄に検索ボタンを配置することで対処

> キーワード検索の検索ボタンは残した方が良いかもしれません。
> 横にログインボタンがあるため，キーワード入力後，間違えてログインボタンを押してしまいそうになる。
> 
> ![image](https://github.com/npocccties/oku-private/assets/8957521/0f97ec6d-f842-4535-93cc-d65dcc12ee3c)

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/208#issuecomment-1988314028_


変更後

![image](https://github.com/npocccties/chiloportal/assets/9744580/2a6c4063-cb5c-42fd-9306-312fed4f5a09)
