### PR TITLE
feat: OZONE-edu → OZONE-EDU

### DIFF
--- a/frontend/examples/concept.md
+++ b/frontend/examples/concept.md
@@ -1,12 +1,12 @@
 ---
-title: OZONE-edu について
+title: OZONE-EDU について
 type: menu
 slug: concept
 order: 1
 ---
 
-## OZONE-edu が目指すこと
+## OZONE-EDU が目指すこと
 
-OZONE-edu の前提とする大阪教育大学のオンライン教育のビジョンは、このような「ビジョンと戦略」となります。
+OZONE-EDU の前提とする大阪教育大学のオンライン教育のビジョンは、このような「ビジョンと戦略」となります。
 
 ![ビジョンと戦略](/fig-pyramid.svg)

--- a/frontend/lib/contents.ts
+++ b/frontend/lib/contents.ts
@@ -1,7 +1,7 @@
 /** グローバルメニューにおける静的コンテンツの並び */
 export default [
   {
-    title: "OZONE-edu について",
+    title: "OZONE-EDU について",
     slug: "concept",
   },
   {

--- a/frontend/lib/title.ts
+++ b/frontend/lib/title.ts
@@ -1,5 +1,5 @@
 /** ページタイトルを生成する関数 */
 export default function title(...fragments: string[]): string {
-  if (fragments.length === 0) return "OZONE-edu";
-  return `${fragments.join(" - ")} - OZONE-edu`;
+  if (fragments.length === 0) return "OZONE-EDU";
+  return `${fragments.join(" - ")} - OZONE-EDU`;
 }

--- a/frontend/templates/Top.tsx
+++ b/frontend/templates/Top.tsx
@@ -23,7 +23,7 @@ export default function Top({ source }: Props) {
           src="/logo.svg"
           width={128}
           height={32}
-          alt="OZONE-edu"
+          alt="OZONE-EDU"
         />
       </h1>
       <p className="text-xl md:text-5xl tracking-tight text-white font-bold mb-10">


### PR DESCRIPTION
> @knokmki612 
> 
> https://github.com/npocccties/oku-private/issues/208#issuecomment-1990971066
> 
> > OZONE-eduの文字表記について未定義である。検討結果としてはOZONE-eduにする。
> 
> 上記の件について，大教大側の回答として，文字の表記は「OZONE-EDU」で確定と連絡がありました。
> 
> お手数ですが，head情報（<title>学びを探す - OZONE-edu</title>など）やメニュー（OZONE-edu について）など，文字表記部分の修正をお願いします。

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/211#issuecomment-1996230321_
            