### PR TITLE
fix: 意図しない環境変数の重複

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_API_MOCKING=true
 NEXT_PUBLIC_API_BASE_URL=https://portal.example.org/api/v1
-NEXT_PUBLIC_API_BASE_URL=https://portal.example.org/
+NEXT_PUBLIC_BASE_URL=https://portal.example.org/
 NEXT_PUBLIC_MOODLE_DASHBOARD_URL=https://lms.example.org/my/


### PR DESCRIPTION
https://github.com/npocccties/chiloportal/commit/76dfad59980f80e4e015fb4f9e1064ef8e5b32a4#diff-8418659e03d1d6494d6c53bd2f591905fdc4369cf108de7b249bb796fb88aa1bR3

@knokmki612 
.env.development ファイル内の環境変数名のミス
3行目は，NEXT_PUBLIC_API_BASE_URLではなく，NEXT_PUBLIC_BASE_URL かと思います。

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/211#issuecomment-2005869310_
            