### PR TITLE
fix: おしらせ名文字列長によって日付が折り返されうる, etc.

### DIFF
--- a/frontend/components/LearningContents.tsx
+++ b/frontend/components/LearningContents.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import Link from "next/link";
+import { Config } from "schemas";
+
+type Props = {
+  className?: string;
+  learningContents: Exclude<Config["learningContents"], undefined>;
+};
+
+export default function LearningContents(props: Props) {
+  return (
+    <ul className={clsx("space-y-4", props.className)}>
+      {props.learningContents.map((learningContent, index) => (
+        <li key={index}>
+          <Link
+            className="flex flex-col gap-4 border-l-4 border-gray-100 pl-4 text-sm hover:bg-gray-50 py-1 [&>span:first-child]:hover:underline"
+            href={learningContent.url}
+            target="_blank"
+          >
+            <span className="text-base font-bold text-gray-700">
+              {learningContent.name}
+            </span>
+            <span className="text-gray-800">{learningContent.description}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/components/PostLink.tsx
+++ b/frontend/components/PostLink.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+import Link, { LinkProps } from "next/link";
+import { Post } from "schemas";
+
+type Props = LinkProps & {
+  className?: string;
+  post: Post;
+};
+
+export default function PostLink({ className, post, ...props }: Props) {
+  return (
+    <Link
+      className={clsx(
+        "flex items-center justify-between gap-4 border-l-4 border-gray-100 pl-4 text-sm hover:bg-gray-50 py-1 pr-1 [&>span:first-child]:hover:underline",
+        className,
+      )}
+      {...props}
+    >
+      <span>{post.title}</span>
+      <span className="p-2 text-xs text-primary-950 bg-gray-100 rounded">
+        {post.datePublished}
+      </span>
+    </Link>
+  );
+}

--- a/frontend/components/PostLink.tsx
+++ b/frontend/components/PostLink.tsx
@@ -17,7 +17,7 @@ export default function PostLink({ className, post, ...props }: Props) {
       {...props}
     >
       <span>{post.title}</span>
-      <span className="p-2 text-xs text-primary-950 bg-gray-100 rounded">
+      <span className="flex-shrink-0 p-2 text-xs text-primary-950 bg-gray-100 rounded">
         {post.datePublished}
       </span>
     </Link>

--- a/frontend/templates/Issuer.tsx
+++ b/frontend/templates/Issuer.tsx
@@ -5,6 +5,8 @@ import { Props } from "pages/issuers/[issuerId]";
 import Container from "components/Container";
 import Breadcrumbs from "components/Breadcrumbs";
 import Image from "next/image";
+import LearningContents from "components/LearningContents";
+import PostLink from "components/PostLink";
 import { getImageUrl } from "lib/issuer";
 
 export default function Issuer({
@@ -115,18 +117,13 @@ export default function Issuer({
             <ul className="space-y-4">
               {posts.map((post) => (
                 <li key={post.slug}>
-                  <Link
-                    className="flex items-center justify-between gap-4 border-l-4 border-gray-100 pl-4 text-sm hover:bg-gray-50 py-1 pr-1 [&>span:first-child]:hover:underline"
+                  <PostLink
+                    post={post}
                     href={pagesPath.issuers
                       ._issuerId(issuer.issuer_id)
                       .posts._slug(post.slug)
                       .$url()}
-                  >
-                    <span>{post.title}</span>
-                    <span className="p-2 text-xs text-primary-950 bg-gray-100 rounded">
-                      {post.datePublished}
-                    </span>
-                  </Link>
+                  />
                 </li>
               ))}
             </ul>
@@ -138,24 +135,7 @@ export default function Issuer({
               </span>
               {issuer.name}のコンテンツ
             </h2>
-            <ul className="space-y-4">
-              {learningContents.map((learningContent, index) => (
-                <li key={index}>
-                  <Link
-                    className="flex flex-col gap-4 border-l-4 border-primary-100 pl-4 text-sm hover:bg-gray-50 py-1 [&>span:first-child]:hover:underline"
-                    href={learningContent.url}
-                    target="_blank"
-                  >
-                    <span className="text-base font-bold text-gray-700">
-                      {learningContent.name}
-                    </span>
-                    <span className="text-gray-800">
-                      {learningContent.description}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
+            <LearningContents learningContents={learningContents} />
           </section>
         </div>
       </Container>

--- a/frontend/templates/Posts.tsx
+++ b/frontend/templates/Posts.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { Icon } from "@iconify/react";
 import { Props } from "pages/posts";
 import Breadcrumbs from "components/Breadcrumbs";
 import Container from "components/Container";
+import PostLink from "components/PostLink";
 import { pagesPath } from "lib/$path";
 
 function Posts({ posts }: Props) {
@@ -22,15 +22,10 @@ function Posts({ posts }: Props) {
       <ul className="space-y-4">
         {posts.map((post) => (
           <li key={post.slug}>
-            <Link
-              className="flex items-center justify-between gap-4 border-l-4 border-gray-100 pl-4 text-sm hover:bg-gray-50 py-1 pr-1 [&>span:first-child]:hover:underline"
+            <PostLink
+              post={post}
               href={pagesPath.posts._slug(post.slug).$url()}
-            >
-              <span>{post.title}</span>
-              <span className="p-2 text-xs text-primary-950 bg-gray-100 rounded">
-                {post.datePublished}
-              </span>
-            </Link>
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
@knokmki612 
おしらせについて，日時エリアがタイトルに押されないようにして欲しい
（[Figma](https://www.figma.com/file/dCE06JShf29eqnvZ4vcE8U/OZONE-EDU?type=design&node-id=1605-11161&mode=design&t=5oSU2VxCiaX2bwKA-0)ではタイトル長くても押されていないので同じように。）

https://o3edu.osaka-kyoiku.ac.jp/issuers/1
![image](https://github.com/npocccties/oku-private/assets/8957521/53f654f4-58bf-4334-af59-76727864565d)

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/211#issuecomment-2006967715_

@knokmki612
提供するコンテンツの左のラインが水色になっていました。お知らせ側のラインと揃っていないから間違えているのかも。（Figmaも灰色ですし）

https://o3edu.osaka-kyoiku.ac.jp/issuers/1
![image](https://github.com/npocccties/oku-private/assets/8957521/bdcbefe0-343b-41fd-b33e-f28ab0c90680)

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/211#issuecomment-2007187729_
            