### PR TITLE
fix: カテゴリー別バッジの件数が組織別ではなく全体で抽出している

### DIFF
--- a/frontend/pages/issuers/[issuerId]/index.tsx
+++ b/frontend/pages/issuers/[issuerId]/index.tsx
@@ -62,7 +62,10 @@ export async function getStaticProps({
     portalCategories.map((portalCategory) =>
       client.badges.list
         .$get({
-          query: { portal_category_id: portalCategory.portal_category_id },
+          query: {
+            issuer_id: Number(issuerId),
+            portal_category_id: portalCategory.portal_category_id,
+          },
         })
         .then(({ total_count }) => total_count)
         .catch(() => 0),


### PR DESCRIPTION
@knokmki612 

組織別の能力バッジのところにあるカテゴリの数が組織別でなく全体で出ているのは想定通りでしょうか？
https://o3edu.osaka-kyoiku.ac.jp/issuers/2

![image](https://github.com/npocccties/oku-private/assets/8957521/d43ae3b7-8077-47d5-adc5-5faaaab170d1)

_Originally posted by @ties-makimura in https://github.com/npocccties/oku-private/issues/211#issuecomment-2011314150_
            