### PR TITLE
fix: ogp `og:` 名前空間宣言が未定義

### DIFF
--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="ja" prefix="og: https://ogp.me/ns#">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
resolve #869