### PR TITLE
feat: Google Analytics 設置

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,6 +53,7 @@ docker run --rm -p 3000:3000 frontend # Docker コンテナの起動
 | NEXT_PUBLIC_BASE_URL                 | ベースとなる URL                               | "https://portal.example.org/" |
 | NEXT_PUBLIC_MOODLE_DASHBOARD_URL     | Moodle ダッシュボードの URL                    | なし                          |
 | NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH | バッジ発行者の画像のパス                       | `"issuer/image.png"`          |
+| NEXT_PUBLIC_GOOGLE_TAG_ID            | Google Analytics に使用する Google タグ ID     | `"G-BL39M953V6"`              |
 
 [^yn]: [yn](https://github.com/sindresorhus/yn#readme)によって truly/falsy な値として解釈されます
 

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -17,3 +17,7 @@ export const NEXT_PUBLIC_MOODLE_DASHBOARD_URL: string =
   process.env.NEXT_PUBLIC_MOODLE_DASHBOARD_URL ?? "";
 export const NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH =
   process.env.NEXT_PUBLIC_BADGES_ISSUER_IMAGE_PATH ?? "issuer/image.png";
+// NOTE: 有効な Google タグ ID を初期値にしたくなければ変更して
+// See https://github.com/npocccties/chiloportal/issues/858
+export const NEXT_PUBLIC_GOOGLE_TAG_ID =
+  process.env.NEXT_PUBLIC_GOOGLE_TAG_ID ?? "G-BL39M953V6";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@faker-js/faker": "^8.4.1",
     "@headlessui/react": "^1.7.18",
     "@iconify/react": "^4.1.1",
+    "@next/third-parties": "^14.2.18",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "aspida": "^1.14.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,8 +2,13 @@ import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import Layout from "components/Layout";
-import { NEXT_PUBLIC_API_MOCKING, NEXT_PUBLIC_BASE_URL } from "lib/env";
+import {
+  NEXT_PUBLIC_API_MOCKING,
+  NEXT_PUBLIC_BASE_URL,
+  NEXT_PUBLIC_GOOGLE_TAG_ID,
+} from "lib/env";
 import { useRouter } from "next/router";
+import { GoogleAnalytics } from "@next/third-parties/google";
 
 if (NEXT_PUBLIC_API_MOCKING) require("../mocks");
 
@@ -24,6 +29,7 @@ function App({ Component, pageProps }: AppProps) {
           content={new URL("/ogp.png", NEXT_PUBLIC_BASE_URL).href}
         />
       </Head>
+      <GoogleAnalytics gaId={NEXT_PUBLIC_GOOGLE_TAG_ID} />
       <Component {...pageProps} />
       <style jsx global>
         {`

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2255,6 +2255,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/third-parties@npm:^14.2.18":
+  version: 14.2.18
+  resolution: "@next/third-parties@npm:14.2.18"
+  dependencies:
+    third-party-capital: "npm:1.0.20"
+  peerDependencies:
+    next: ^13.0.0 || ^14.0.0
+    react: ^18.2.0
+  checksum: b6aa495cdf66817b5efa98c61bde9e0038f88bf491e40a4952cf66e9c5dd16ed2b51b1be9d027d14865ed61fa6a29da320c6c1ba1156c3e92249b0dd32a79c0f
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -5288,6 +5300,7 @@ __metadata:
     "@headlessui/react": "npm:^1.7.18"
     "@iconify/react": "npm:^4.1.1"
     "@jumpu-ui/tailwindcss": "npm:^1.0.1-alpha.6"
+    "@next/third-parties": "npm:^14.2.18"
     "@svgr/webpack": "npm:^8.1.0"
     "@tailwindcss/typography": "npm:^0.5.10"
     "@types/node": "npm:^20.11.24"
@@ -10119,6 +10132,13 @@ __metadata:
   dependencies:
     any-promise: "npm:^1.0.0"
   checksum: 486e1283a867440a904e36741ff1a177faa827cf94d69506f7e3ae4187b9afdf9ec368b3d8da225c192bfe2eb943f3f0080594156bf39f21b57cd1411e2e7f6d
+  languageName: node
+  linkType: hard
+
+"third-party-capital@npm:1.0.20":
+  version: 1.0.20
+  resolution: "third-party-capital@npm:1.0.20"
+  checksum: 40e2531b428a21f05531fc62ef82859c0071211eff09588baf75d4b525096bbdb4f93e17e2d538849db8d4fc3cceb074933d7be59fddc26f86718fbbe852a97f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ref https://github.com/npocccties/chiloportal/issues/858

- 動作検証のための Google タグ ID をハードコーディングしています
- Google タグ ID は環境変数 `NEXT_PUBLIC_GOOGLE_TAG_ID` により変更可能です