### PR TITLE
受講中のコース & 獲得済みのバッジの並びと分類

### DIFF
--- a/frontend/lib/badge-status-list.test.ts
+++ b/frontend/lib/badge-status-list.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "vitest";
+import {
+  isCurrentCourse,
+  isEarnedBadge,
+  isEarnableBadge,
+  sortByDescendingAccessDateTime,
+  sortByDescendingImportDateTime,
+} from "./badge-status-list";
+import { BadgeStatusList, BadgeStatus } from "pages/dashboard";
+
+const base: BadgeStatus = {
+  enrolled: false,
+  issued: false,
+  imported: false,
+  submitted: false,
+  lms_id: 0,
+  lms_name: "LMS",
+};
+
+describe("受講中のコースの判定", () => {
+  test("受講中かつ未インポートのとき該当", () => {
+    const status: BadgeStatus = {
+      ...base,
+      enrolled: true,
+    };
+    const result = isCurrentCourse(status);
+    expect(result).toEqual(true);
+  });
+  test("受講中かつインポート済みのとき非該当", () => {
+    const status: BadgeStatus = {
+      ...base,
+      enrolled: true,
+      imported: true,
+    };
+    const result = isCurrentCourse(status);
+    expect(result).toEqual(false);
+  });
+  test("未受講かつ未インポートのとき非該当", () => {
+    const status: BadgeStatus = base;
+    const result = isCurrentCourse(status);
+    expect(result).toEqual(false);
+  });
+});
+
+describe("獲得済みのバッジの判定", () => {
+  test("受講中かつ未インポートのとき該当", () => {
+    const status: BadgeStatus = {
+      ...base,
+      imported: true,
+    };
+    const result = isEarnedBadge(status);
+    expect(result).toEqual(true);
+  });
+  test("未インポートのとき非該当", () => {
+    const status: BadgeStatus = base;
+    const result = isEarnedBadge(status);
+    expect(result).toEqual(false);
+  });
+});
+
+describe("獲得可能なバッジの判定", () => {
+  test("発行済みかつ未インポートのとき該当", () => {
+    const status: BadgeStatus = {
+      ...base,
+      issued: true,
+    };
+    const result = isEarnableBadge(status);
+    expect(result).toEqual(true);
+  });
+  test("発行済みかつインポート済みのとき非該当", () => {
+    const status: BadgeStatus = {
+      ...base,
+      issued: true,
+      imported: true,
+    };
+    const result = isEarnableBadge(status);
+    expect(result).toEqual(false);
+  });
+  test("未発行かつ未インポートのとき非該当", () => {
+    const status: BadgeStatus = base;
+    const result = isEarnableBadge(status);
+    expect(result).toEqual(false);
+  });
+});
+
+test("最終アクセス日時降順に並べ替え", () => {
+  const badgeStatusList: BadgeStatusList = [
+    { ...base, accessed_at: "2025-05-01T00:00:01.000Z" },
+    { ...base, accessed_at: "2025-05-01T00:00:03.000Z" },
+    { ...base, accessed_at: "2025-05-01T00:00:02.000Z" },
+  ];
+  const result = badgeStatusList.toSorted(sortByDescendingAccessDateTime);
+  expect(result).toEqual([
+    { ...base, accessed_at: "2025-05-01T00:00:03.000Z" },
+    { ...base, accessed_at: "2025-05-01T00:00:02.000Z" },
+    { ...base, accessed_at: "2025-05-01T00:00:01.000Z" },
+  ]);
+});
+
+test("インポート日時降順に並べ替え", () => {
+  const badgeStatusList: BadgeStatusList = [
+    { ...base, imported_at: "2025-05-01T00:00:01.000Z" },
+    { ...base, imported_at: "2025-05-01T00:00:03.000Z" },
+    { ...base, imported_at: "2025-05-01T00:00:02.000Z" },
+  ];
+  const result = badgeStatusList.toSorted(sortByDescendingImportDateTime);
+  expect(result).toEqual([
+    { ...base, imported_at: "2025-05-01T00:00:03.000Z" },
+    { ...base, imported_at: "2025-05-01T00:00:02.000Z" },
+    { ...base, imported_at: "2025-05-01T00:00:01.000Z" },
+  ]);
+});

--- a/frontend/lib/badge-status-list.ts
+++ b/frontend/lib/badge-status-list.ts
@@ -1,0 +1,75 @@
+import { BadgeStatus, BadgeStatusList } from "pages/dashboard";
+import groupBy from "just-group-by";
+
+/** 受講中のコースの判定
+ *
+ * 受講中かつ未インポートを受講中のコースとみなします
+ **/
+export function isCurrentCourse(status: BadgeStatus): boolean {
+  return status.enrolled && !status.imported;
+}
+
+/**
+ * 獲得済みのバッジの判定
+ *
+ * インポート済みを獲得済みのバッジとみなします
+ **/
+export function isEarnedBadge(status: BadgeStatus): boolean {
+  return status.imported;
+}
+
+/**
+ * 獲得可能なバッジの判定
+ *
+ * バッジ発行済みかつ未インポートを獲得可能なバッジとみなします
+ **/
+export function isEarnableBadge(status: BadgeStatus): boolean {
+  return status.issued && !status.imported;
+}
+
+/**
+ * 獲得可能か否かによるグループ化
+ */
+export function groupByEarnable(statusList: BadgeStatusList): {
+  earnable?: BadgeStatusList;
+  unearnable?: BadgeStatusList;
+} {
+  return groupBy(statusList, (status) =>
+    isEarnableBadge(status) ? "earnable" : "unearnable",
+  );
+}
+
+/**
+ * エポックミリ秒への変換
+ * @param iso8601 ISO 8601 形式
+ * @description 値が undefined のとき、0 を返します。
+ * @returns エポックミリ秒
+ */
+export function toEpochMillis(iso8601?: string): number {
+  if (!iso8601) return 0;
+  return Date.parse(iso8601);
+}
+
+/** 最終アクセス日時降順にする比較関数 */
+export function sortByDescendingAccessDateTime(
+  a: BadgeStatus,
+  b: BadgeStatus,
+): number {
+  const aMillis = toEpochMillis(a.accessed_at);
+  const bMillis = toEpochMillis(b.accessed_at);
+  if (aMillis > bMillis) return -1;
+  if (aMillis < bMillis) return 1;
+  return 0;
+}
+
+/** インポート日時降順にする比較関数 */
+export function sortByDescendingImportDateTime(
+  a: BadgeStatus,
+  b: BadgeStatus,
+): number {
+  const aMillis = toEpochMillis(a.imported_at);
+  const bMillis = toEpochMillis(b.imported_at);
+  if (aMillis > bMillis) return -1;
+  if (aMillis < bMillis) return 1;
+  return 0;
+}

--- a/frontend/mocks/handlers.ts
+++ b/frontend/mocks/handlers.ts
@@ -1,5 +1,5 @@
-import { http, HttpResponse } from "msw";
-import { client } from "lib/client";
+import { http, HttpResponse, passthrough } from "msw";
+import { client, chilowalletClient } from "lib/client";
 import {
   consumer,
   issuer,
@@ -69,4 +69,5 @@ export const handlers = [
   http.get(client.consumer.badges.list.$path(), () =>
     HttpResponse.json([...Array(3)].map(consumerBadge)),
   ),
+  http.get(chilowalletClient.badge.status.list.$path(), () => passthrough()),
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "image-size": "^2.0.2",
     "jose": "^6.0.10",
     "jotai": "^2.12.2",
+    "just-group-by": "^2.2.0",
     "msw": "^2.7.3",
     "next": "^15.3.0",
     "next-mdx-remote": "^5.0.0",

--- a/frontend/pages/api/verify-cookie.ts
+++ b/frontend/pages/api/verify-cookie.ts
@@ -16,7 +16,7 @@ export default async function handler(
 ) {
   const key = await importSPKI(atob(JWT_VERIFICATION_KEY_BASE64), "RS256");
   const verified = await jwtVerify<UserAttributes>(
-    req.cookies["session_cookie"] ?? JWT_DEBUG_VALUE,
+    req.cookies.session_cookie ?? JWT_DEBUG_VALUE,
     key,
   );
   res.status(200).json(verified.payload);

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -37,7 +37,7 @@ export async function getServerSideProps({
     const badgeStatusList = await chilowalletClient.badge.status.list.$get({
       config: {
         headers: {
-          Cookie: `session_cookie=${req.cookies["session_cookie"] ?? JWT_DEBUG_VALUE}`,
+          Cookie: `session_cookie=${req.cookies.session_cookie ?? JWT_DEBUG_VALUE}`,
         },
       },
     });

--- a/frontend/templates/Dashboard.tsx
+++ b/frontend/templates/Dashboard.tsx
@@ -3,7 +3,12 @@ import Breadcrumbs from "components/Breadcrumbs";
 import Container from "components/Container";
 import { pagesPath } from "lib/$path";
 
-function Dashboard({ tab: _, badgeStatusList }: Props) {
+function Dashboard({
+  tab: _tab,
+  currentCourses,
+  earnedBadges,
+  errorCode: _errorCode,
+}: Props) {
   return (
     <Container>
       <Breadcrumbs
@@ -14,7 +19,8 @@ function Dashboard({ tab: _, badgeStatusList }: Props) {
       <h1 className="text-3xl font-bold hidden md:block mb-8 border-b border-gray-300 pb-2">
         ダッシュボード
       </h1>
-      <pre>{JSON.stringify(badgeStatusList, null, 2)}</pre>
+      <pre>{JSON.stringify(currentCourses, null, 2)}</pre>
+      <pre>{JSON.stringify(earnedBadges, null, 2)}</pre>
     </Container>
   );
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5813,6 +5813,7 @@ __metadata:
     jose: "npm:^6.0.10"
     jotai: "npm:^2.12.2"
     json-schema-to-ts: "npm:^3.1.1"
+    just-group-by: "npm:^2.2.0"
     msw: "npm:^2.7.3"
     next: "npm:^15.3.0"
     next-mdx-remote: "npm:^5.0.0"
@@ -6907,6 +6908,13 @@ __metadata:
     object.assign: "npm:^4.1.4"
     object.values: "npm:^1.1.6"
   checksum: 10/b61d44613687dfe4cc8ad4b4fbf3711bf26c60b8d5ed1f494d723e0808415c59b24a7c0ed8ab10736a40ff84eef38cbbfb68b395e05d31117b44ffc59d31edfc
+  languageName: node
+  linkType: hard
+
+"just-group-by@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "just-group-by@npm:2.2.0"
+  checksum: 10/943664c7310df37031356f0ee2605ea46499880cf5bd9203de19082e9a705e4ef7e01769bcad55e314d7c814e1bb89811e7737a776c6d152e1eb214201a2d9bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
resolve https://github.com/npocccties/oku-private/issues/242 , resolve https://github.com/npocccties/chiloportal/issues/911

- 受講中かつ未インポートのとき受講中のコースに分類
- インポート済みのとき獲得済みのバッジに分類
- 獲得済みのバッジはインポート日時降順に並べ替え
- 受講中のバッジは次に並べ替え
  - 最終アクセス日時降順に並べ替え
  - 発行済みかつ未インポートを優先