### PR TITLE
fix(markdown): .next/server/* から contents ディレクトリを探索する

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -32,6 +32,7 @@ RUN yarn workspaces focus --all --production
 FROM gcr.io/distroless/nodejs22-debian12
 WORKDIR /app
 ENV NODE_ENV=production
+COPY frontend/contents/ ./contents
 COPY frontend/public/ ./public
 COPY --from=build /app/.next ./.next
 COPY --from=install /app/node_modules ./node_modules

--- a/frontend/lib/markdown.ts
+++ b/frontend/lib/markdown.ts
@@ -1,5 +1,6 @@
 import { JSONSchema } from "json-schema-to-ts";
 import { join } from "node:path";
+import { findUp } from "find-up";
 import { read } from "to-vfile";
 import { matter } from "vfile-matter";
 import { VFile } from "vfile";
@@ -84,9 +85,10 @@ export async function readMarkdowns<T extends Frontmatter["type"]>({
   issuerId?: number;
   allIssuer?: boolean;
 }): Promise<Error | MarkdownResult<T>[]> {
-  const dirname = "contents";
-  const contents = await fg.async(join(dirname, "**", "*.md"));
-  const dirPath = contents.length > 0 ? dirname : "examples";
+  const contentsPath =
+    (await findUp("contents", { type: "directory" })) ?? "./contents";
+  const contents = await fg.async(join(contentsPath, "**", "*.md"));
+  const dirPath = contents.length > 0 ? contentsPath : "examples";
   const filePaths = await fg.async(join(dirPath, "**", "*.md"));
   if (filePaths.length === 0) return [];
   const markdowns = await Promise.all(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "cross-fetch": "^4.1.0",
     "fast-glob": "^3.3.3",
+    "find-up": "^7.0.0",
     "http-errors-enhanced": "^3.0.2",
     "image-size": "^2.0.2",
     "isomorphic-dompurify": "^2.24.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5827,6 +5827,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "find-up@npm:7.0.0"
+  dependencies:
+    locate-path: "npm:^7.2.0"
+    path-exists: "npm:^5.0.0"
+    unicorn-magic: "npm:^0.1.0"
+  checksum: 10/7e6b08fbc05a10677e25e74bb0a020054a86b31d1806c5e6a9e32e75472bbf177210bc16e5f97453be8bda7ae2e3d97669dbb2901f8c30b39ce53929cbea6746
+  languageName: node
+  linkType: hard
+
 "fixpack@npm:^4.0.0":
   version: 4.0.0
   resolution: "fixpack@npm:4.0.0"
@@ -5919,6 +5930,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.2"
     eslint-plugin-canonical: "npm:^5.1.3"
     fast-glob: "npm:^3.3.3"
+    find-up: "npm:^7.0.0"
     fixpack: "npm:^4.0.0"
     http-errors-enhanced: "npm:^3.0.2"
     image-size: "npm:^2.0.2"
@@ -7260,6 +7272,15 @@ __metadata:
   dependencies:
     p-locate: "npm:^5.0.0"
   checksum: 10/72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "locate-path@npm:7.2.0"
+  dependencies:
+    p-locate: "npm:^6.0.0"
+  checksum: 10/1c6d269d4efec555937081be964e8a9b4a136319c79ca1d45ac6382212a8466113c75bd89e44521ca8ecd1c47fb08523b56eee5c0712bc7d14fec5f729deeb42
   languageName: node
   linkType: hard
 
@@ -8751,12 +8772,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: "npm:^1.0.0"
+  checksum: 10/01d9d70695187788f984226e16c903475ec6a947ee7b21948d6f597bed788e3112cc7ec2e171c1d37125057a5f45f3da21d8653e04a3a793589e12e9e80e756b
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
   dependencies:
     p-limit: "npm:^3.0.2"
   checksum: 10/1623088f36cf1cbca58e9b61c4e62bf0c60a07af5ae1ca99a720837356b5b6c5ba3eb1b2127e47a06865fee59dd0453cad7cc844cda9d5a62ac1a5a51b7c86d3
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "p-locate@npm:6.0.0"
+  dependencies:
+    p-limit: "npm:^4.0.0"
+  checksum: 10/2bfe5234efa5e7a4e74b30a5479a193fdd9236f8f6b4d2f3f69e3d286d9a7d7ab0c118a2a50142efcf4e41625def635bd9332d6cbf9cc65d85eb0718c579ab38
   languageName: node
   linkType: hard
 
@@ -8833,6 +8872,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10/505807199dfb7c50737b057dd8d351b82c033029ab94cb10a657609e00c1bc53b951cfdbccab8de04c5584d5eff31128ce6afd3db79281874a5ef2adbba55ed1
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "path-exists@npm:5.0.0"
+  checksum: 10/8ca842868cab09423994596eb2c5ec2a971c17d1a3cb36dbf060592c730c725cd524b9067d7d2a1e031fef9ba7bd2ac6dc5ec9fb92aa693265f7be3987045254
   languageName: node
   linkType: hard
 
@@ -10831,6 +10877,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unicorn-magic@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "unicorn-magic@npm:0.1.0"
+  checksum: 10/9b4d0e9809807823dc91d0920a4a4c0cff2de3ebc54ee87ac1ee9bc75eafd609b09d1f14495e0173aef26e01118706196b6ab06a75fe0841028b3983a8af313f
+  languageName: node
+  linkType: hard
+
 "unified@npm:^11.0.0, unified@npm:^11.0.5":
   version: 11.0.5
   resolution: "unified@npm:11.0.5"
@@ -11573,6 +11626,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.0.0":
+  version: 1.2.1
+  resolution: "yocto-queue@npm:1.2.1"
+  checksum: 10/0843d6c2c0558e5c06e98edf9c17942f25c769e21b519303a5c2adefd5b738c9b2054204dc856ac0cd9d134b1bc27d928ce84fd23c9e2423b7e013d5a6f50577
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix: #928

SSR 時にマークダウン記事を取得、表示に使用する目的

確認方法

1. cd frontend
2. cp examples/post.md contents/
3. docker build -t frontend -f ../Dockerfile.frontend ..
4. docker run --env JWT_VERIFICATION_KEY=xxx --rm -p 3000:3000 frontend

スクリーンショット

![image](https://github.com/user-attachments/assets/245abc82-9ab6-4c57-896a-c5a3918e476f)