### PR TITLE
feat: 受講中のコースまたは獲得したバッジの選択不可を時限的に表示する

### DIFF
--- a/frontend/components/CurrentCourse.tsx
+++ b/frontend/components/CurrentCourse.tsx
@@ -20,7 +20,10 @@ function CurrentCourse(props: Props) {
     : false;
   const earnable = !isExpired && props.issued;
   const ref = useRef<HTMLInputElement>(null);
-  const showInvalidity = () => {
+  const clearValidity = () => {
+    ref.current?.setCustomValidity("");
+  };
+  const showValidity = () => {
     if (!ref.current || ref.current?.ariaDisabled === "false") return;
     const message =
       (isExpired && messages.expired) ||
@@ -29,13 +32,11 @@ function CurrentCourse(props: Props) {
     ref.current.setCustomValidity(message);
     ref.current.reportValidity();
     ref.current.checked = false;
+    setTimeout(clearValidity, 3_000);
   };
   const handleClick = () => {
     ref.current?.click();
-    showInvalidity();
-  };
-  const handleBlur = () => {
-    ref.current?.setCustomValidity("");
+    showValidity();
   };
   return (
     <div
@@ -43,7 +44,7 @@ function CurrentCourse(props: Props) {
         "jumpu-card pl-4 pr-6 py-4 flex items-center gap-4 has-checked:bg-primary-50 relative"
       }
       onClick={handleClick}
-      onBlur={handleBlur}
+      onBlur={clearValidity}
     >
       <input
         type="checkbox"
@@ -60,7 +61,7 @@ function CurrentCourse(props: Props) {
         }}
         onClick={(e) => {
           e.stopPropagation();
-          showInvalidity();
+          showValidity();
         }}
         aria-disabled={!earnable}
       />

--- a/frontend/components/EarnedBadge.tsx
+++ b/frontend/components/EarnedBadge.tsx
@@ -85,7 +85,10 @@ function EarnedBadge(props: Props) {
   const imageUrl: string | undefined =
     typeof badge.image === "string" ? badge.image : badge.image?.id;
   const ref = useRef<HTMLInputElement>(null);
-  const showInvalidity = () => {
+  const clearValidity = () => {
+    ref.current?.setCustomValidity("");
+  };
+  const showValidity = () => {
     if (!ref.current || ref.current?.ariaDisabled === "false") return;
     const message =
       (isExpired && messages.expired) ||
@@ -94,13 +97,11 @@ function EarnedBadge(props: Props) {
     ref.current.setCustomValidity(message);
     ref.current.reportValidity();
     ref.current.checked = false;
+    setTimeout(clearValidity, 3_000);
   };
   const handleClick = () => {
     ref.current?.click();
-    showInvalidity();
-  };
-  const handleBlur = () => {
-    ref.current?.setCustomValidity("");
+    showValidity();
   };
   return (
     <div
@@ -108,7 +109,7 @@ function EarnedBadge(props: Props) {
         "jumpu-card pl-4 pr-6 py-4 flex items-center gap-4 has-checked:bg-primary-50 relative"
       }
       onClick={handleClick}
-      onBlur={handleBlur}
+      onBlur={clearValidity}
     >
       <input
         type="checkbox"
@@ -125,7 +126,7 @@ function EarnedBadge(props: Props) {
         }}
         onClick={(e) => {
           e.stopPropagation();
-          showInvalidity();
+          showValidity();
         }}
         aria-disabled={!submittable}
       />


### PR DESCRIPTION
非フォーカス（blur）になるまで表示する場合、表示領域を専有するため
閲覧者が非フォーカスに出来ずに裏に隠れた情報に閲覧できない可能性が
あります。
3秒経過したら表示を解消する実装にすることで対処します。