### PR TITLE
feat: トップページからお知らせリンクを削除

### DIFF
--- a/frontend/templates/Top.tsx
+++ b/frontend/templates/Top.tsx
@@ -39,12 +39,6 @@ export default function Top({ source }: Props) {
           className="text-base text-gray-500 absolute right-4 top-1/2 -translate-y-1/2"
         />
       </Link>
-      <Link
-        href={pagesPath.posts.$url()}
-        className="block text-sm text-white underline underline-offset-4 mb-24"
-      >
-        オゾンからのお知らせ
-      </Link>
       {source && <Markdown {...source} />}
     </article>
   );


### PR DESCRIPTION
表示はcustomで行った方が融通が利く